### PR TITLE
Add experimental :vulkan image variant (stock upstream Ollama + Mesa ANV)

### DIFF
--- a/.github/build-vulkan.yml
+++ b/.github/build-vulkan.yml
@@ -1,0 +1,82 @@
+# STAGED WORKFLOW — move this file to .github/workflows/build-vulkan.yml
+# (it was committed here because the automation token cannot write to
+# .github/workflows/; a rename via the GitHub web UI completes the setup)
+name: Build and Push Vulkan Variant to GHCR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.vulkan
+      - start-vulkan.sh
+      - .github/workflows/build-vulkan.yml
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=vulkan
+            type=raw,value=vulkan-${{ github.run_number }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build for smoke test
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.vulkan
+          load: true
+          tags: smoke-test:vulkan
+          cache-from: type=gha,scope=vulkan
+          cache-to: type=gha,mode=max,scope=vulkan
+
+      - name: Smoke test (server starts, API responds)
+        run: |
+          docker run -d --name smoke -p 11434:11434 smoke-test:vulkan
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:11434/api/version; then ok=1; break; fi
+            sleep 2
+          done
+          echo
+          docker logs smoke
+          [ "$ok" = "1" ]
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.vulkan
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=vulkan
+          cache-to: type=gha,mode=max,scope=vulkan

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -1,6 +1,3 @@
-# STAGED WORKFLOW — move this file to .github/workflows/build-vulkan.yml
-# (it was committed here because the automation token cannot write to
-# .github/workflows/; a rename via the GitHub web UI completes the setup)
 name: Build and Push Vulkan Variant to GHCR
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to ollama-intel will be documented in this file.
 
+## [v1.2] - 2026-07-05
+
+### Added
+- **Experimental `:vulkan` image variant** — stock upstream Ollama with the Vulkan backend (Mesa/ANV) on Intel iGPUs. Tracks official Ollama releases, so the newest models and features work immediately; much smaller image than the oneAPI/SYCL build. Known upstream caveat: some iGPUs (e.g. Arrow Lake with 3B+ models) can produce garbled output — `OLLAMA_FLASH_ATTENTION=0` is the documented workaround, or fall back to `:latest`
+- `unraid-template-vulkan.xml` — separate Unraid template for the Vulkan variant (passes the whole `/dev/dri`, exposes `GGML_VK_VISIBLE_DEVICES`, `OLLAMA_FLASH_ATTENTION`, `OLLAMA_IGPU_ENABLE`)
+- `build-vulkan.yml` workflow — weekly rebuild tracking the latest Ollama release, with a smoke test (`/api/version`) before pushing to GHCR
+
 ## [v1.1] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to ollama-intel will be documented in this file.
 
-## [v1.2] - 2026-07-05
+## [v1.3] - 2026-07-05
 
 ### Added
 - **Experimental `:vulkan` image variant** — stock upstream Ollama with the Vulkan backend (Mesa/ANV) on Intel iGPUs. Tracks official Ollama releases, so the newest models and features work immediately; much smaller image than the oneAPI/SYCL build. Known upstream caveat: some iGPUs (e.g. Arrow Lake with 3B+ models) can produce garbled output — `OLLAMA_FLASH_ATTENTION=0` is the documented workaround, or fall back to `:latest`
 - `unraid-template-vulkan.xml` — separate Unraid template for the Vulkan variant (passes the whole `/dev/dri`, exposes `GGML_VK_VISIBLE_DEVICES`, `OLLAMA_FLASH_ATTENTION`, `OLLAMA_IGPU_ENABLE`)
 - `build-vulkan.yml` workflow — weekly rebuild tracking the latest Ollama release, with a smoke test (`/api/version`) before pushing to GHCR
 
-## [v1.1] - 2026-07-04
+## [v1.2] - 2026-07-05
 
 ### Fixed
 - `start.sh` no longer hardcodes oneAPI 2025.0 library paths — paths are now discovered at startup, so a future base image bump can't silently break linking
@@ -23,6 +23,21 @@ All notable changes to ollama-intel will be documented in this file.
 - Unraid template: added `ONEAPI_DEVICE_SELECTOR`, `OLLAMA_NUM_PARALLEL`, and `TZ` as advanced fields
 - Dockerfile now documents why the base image, compute runtime, and IGC versions are pinned (they must match Intel's ipex-llm-tested stack)
 - README: clarified that the bundled Ollama version comes from IPEX-LLM and trails official Ollama releases
+
+## [v1.1] - 2026-04-16
+
+*(Retroactive entry — this release was tagged before its changes were recorded in the changelog.)*
+
+### Changed
+- Rebuilt from source: `intel/oneapi-basekit` base image + `pip install ipex-llm[cpp]`, so weekly rebuilds pick up the latest IPEX-LLM
+- Use the Intel XPU PyTorch wheel index to avoid downloading NVIDIA CUDA packages
+
+### Added
+- `ONEAPI_DEVICE_SELECTOR` (GPU selection) and `OLLAMA_NUM_PARALLEL` (parallel request limit) support in `start.sh`
+- README: NPU status section, Updating section, multi-GPU troubleshooting
+
+### Fixed
+- Removed empty `ONEAPI_DEVICE_SELECTOR` ENV from the Dockerfile — an empty value breaks SYCL device detection
 
 ## [v1.0] - 2026-02-21
 

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -1,0 +1,28 @@
+# ollama-intel :vulkan variant — stock upstream Ollama on Intel iGPUs via the
+# Vulkan backend (Mesa ANV driver). Unlike the SYCL/IPEX-LLM image, this
+# tracks official Ollama releases, so new models and features land
+# immediately — at the cost of using Ollama's newer, still-maturing Vulkan
+# backend. See the README "Vulkan Variant" section for caveats.
+#
+# The upstream ollama/ollama image already bundles the Vulkan backend; all we
+# add is the Intel userspace driver (Mesa ANV) and iGPU opt-in.
+ARG OLLAMA_VERSION=latest
+FROM ollama/ollama:${OLLAMA_VERSION}
+
+# Mesa ANV is the Vulkan ICD for Intel iGPUs; vulkan-tools provides
+# vulkaninfo for startup logging and troubleshooting
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libvulkan1 mesa-vulkan-drivers vulkan-tools && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ollama drops integrated GPUs by default ("dropping integrated GPU; to
+# enable, set OLLAMA_IGPU_ENABLE=1") — opting in is the point of this image
+ENV OLLAMA_HOST=0.0.0.0:11434 \
+    OLLAMA_IGPU_ENABLE=1 \
+    TZ=UTC
+
+COPY start-vulkan.sh /start-vulkan.sh
+RUN chmod +x /start-vulkan.sh
+
+ENTRYPOINT ["/start-vulkan.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This means you can run AI models like Llama 3, Phi-4, Gemma 3, and more — enti
 - 📦 **Drop-in Ollama Replacement** — Compatible with Open WebUI, Chatbox, and any Ollama client
 - 🔧 **Optimized for Unraid** — br0 networking, XML template, persistent model storage
 - ⚡ **Shader Caching** — First run compiles SYCL shaders; subsequent runs are much faster
+- 🌋 **Vulkan Variant** — optional experimental `:vulkan` tag running stock upstream Ollama (latest models, smaller image)
 - 🏠 **Fully Local & Private** — No cloud, no API keys, no data leaves your network
 
 ## 📊 Performance
@@ -126,7 +127,7 @@ Alternatively, paste the template URL directly in Unraid:
 
 Updates are **seamless** on Unraid — just click **Update** in the Docker tab. The container image is rebuilt weekly from source via GitHub Actions, so each update picks up the latest ipex-llm build automatically.
 
-> ℹ️ The Ollama binary inside the container is the one bundled by IPEX-LLM, which trails official Ollama releases (IPEX-LLM currently tracks Ollama v0.9.x). Brand-new Ollama features and model formats may not be available until Intel updates IPEX-LLM.
+> ℹ️ The Ollama binary inside the container is the one bundled by IPEX-LLM, which trails official Ollama releases (IPEX-LLM currently tracks Ollama v0.9.x). Brand-new Ollama features and model formats may not be available until Intel updates IPEX-LLM. Need the newest Ollama? Try the experimental [Vulkan variant](#-vulkan-variant-experimental).
 
 No need to remove and reinstall. Your models, settings, and SYCL shader cache are stored in the mounted volume and persist across updates.
 
@@ -146,6 +147,47 @@ No need to remove and reinstall. Your models, settings, and SYCL shader cache ar
 | `SYCL_CACHE_PERSISTENT` | `1` | Cache compiled SYCL shaders between restarts |
 | `ZES_ENABLE_SYSMAN` | `1` | Enable Intel GPU system management |
 | `SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS` | `1` | Performance optimization for Level Zero backend |
+
+## 🌋 Vulkan Variant (Experimental)
+
+The `:vulkan` tag runs **stock upstream Ollama** with its Vulkan backend on the Intel iGPU via the open-source Mesa (ANV) driver — no IPEX-LLM, no oneAPI toolkit.
+
+| | `:latest` (SYCL / IPEX-LLM) | `:vulkan` |
+|---|---|---|
+| **Ollama version** | Bundled by IPEX-LLM (trails upstream, ~v0.9.x) | Latest official release |
+| **New models/features** | After Intel updates IPEX-LLM | Immediately |
+| **Image size** | Very large (full oneAPI toolkit) | Small |
+| **Maturity** | Stable, Intel-validated stack | Experimental upstream backend |
+
+```bash
+docker run -d \\
+  --name ollama-intel-vulkan \\
+  --restart unless-stopped \\
+  -p 11434:11434 \\
+  --device /dev/dri \\
+  -v /mnt/user/appdata/ollama:/root/.ollama \\
+  -e OLLAMA_KEEP_ALIVE=30s \\
+  ghcr.io/ava-agentone/ollama-intel:vulkan
+```
+
+Unraid template URL:
+```
+https://raw.githubusercontent.com/Ava-AgentOne/ollama-intel/main/unraid-template-vulkan.xml
+```
+
+**Extra environment variables (`:vulkan` only):**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_IGPU_ENABLE` | `1` (set in image) | Ollama drops iGPUs by default; this opts back in |
+| `GGML_VK_VISIBLE_DEVICES` | `` | Restrict to specific Vulkan device IDs (e.g., `0`) |
+| `OLLAMA_FLASH_ATTENTION` | `` | Set to `0` if you get garbled output on your iGPU |
+| `OLLAMA_VULKAN` | | Set to `0` to disable the Vulkan backend entirely |
+
+**Caveats:**
+
+- Upstream Vulkan support is still maturing. Some Intel iGPUs — notably Arrow Lake with models ≥3B — have produced garbled output ([ollama#13964](https://github.com/ollama/ollama/issues/13964), [ollama#13086](https://github.com/ollama/ollama/issues/13086)). If that happens, try `OLLAMA_FLASH_ATTENTION=0`, a smaller model, or fall back to `:latest`.
+- Models are stored in the same format, so both variants can share the same appdata volume and you can switch tags without re-downloading — but **don't run both containers at the same time** (they would race on the model store and fight over the iGPU).
 
 ## 🛡️ NPU Support
 
@@ -222,6 +264,12 @@ If you have both an integrated and discrete GPU, set `ONEAPI_DEVICE_SELECTOR` to
 ```
 
 Check device IDs with: `docker exec ollama-intel sycl-ls`
+</details>
+
+<details>
+<summary><strong>Vulkan variant: garbled or nonsense output</strong></summary>
+
+A known upstream issue on some Intel iGPUs (especially Arrow Lake with 3B+ models). Try `-e OLLAMA_FLASH_ATTENTION=0`, use a smaller model, or switch to the stable `:latest` (SYCL) image.
 </details>
 
 ## 📜 License

--- a/start-vulkan.sh
+++ b/start-vulkan.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Unraid passes optional template variables as empty strings — unset them so
+# they don't override Ollama's defaults with empty values
+[ -z "${GGML_VK_VISIBLE_DEVICES:-}" ] && unset GGML_VK_VISIBLE_DEVICES
+[ -z "${OLLAMA_FLASH_ATTENTION:-}" ] && unset OLLAMA_FLASH_ATTENTION
+[ -z "${OLLAMA_NUM_PARALLEL:-}" ] && unset OLLAMA_NUM_PARALLEL
+
+echo "[ollama-intel:vulkan] Vulkan devices:"
+vulkaninfo --summary 2>/dev/null | grep -E 'deviceName|driverName' || echo "  (no Vulkan device detected — is /dev/dri passed through?)"
+
+if [ -n "${GGML_VK_VISIBLE_DEVICES:-}" ]; then
+    echo "[ollama-intel:vulkan] Device filter: $GGML_VK_VISIBLE_DEVICES"
+fi
+
+if [ -n "${OLLAMA_NUM_PARALLEL:-}" ]; then
+    echo "[ollama-intel:vulkan] Parallel requests: $OLLAMA_NUM_PARALLEL"
+fi
+
+echo "[ollama-intel:vulkan] Starting Ollama..."
+ollama --version 2>/dev/null || true
+# exec so ollama runs as PID 1 and receives SIGTERM on container stop
+exec ollama serve

--- a/unraid-template-vulkan.xml
+++ b/unraid-template-vulkan.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>ollama-intel-vulkan</Name>
+  <Repository>ghcr.io/ava-agentone/ollama-intel:vulkan</Repository>
+  <Registry>https://github.com/Ava-AgentOne/ollama-intel/pkgs/container/ollama-intel</Registry>
+  <Network>br0</Network>
+  <MyIP/>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Ava-AgentOne/ollama-intel</Support>
+  <Project>https://github.com/Ava-AgentOne/ollama-intel</Project>
+  <Overview>EXPERIMENTAL: Ollama with Intel iGPU acceleration via the Vulkan backend (Mesa/ANV). Runs stock upstream Ollama, so the newest models and features work immediately and the image is much smaller than the SYCL build. If you get garbled output on your iGPU, try OLLAMA_FLASH_ATTENTION=0 or use the stable SYCL image (ollama-intel:latest). Do not run both variants against the same GPU at the same time.</Overview>
+  <Category>AI: Tools:</Category>
+  <WebUI/>
+  <TemplateURL>https://raw.githubusercontent.com/Ava-AgentOne/ollama-intel/main/unraid-template-vulkan.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Ava-AgentOne/ollama-intel/main/icon.png</Icon>
+  <ExtraParams>--restart unless-stopped --device /dev/dri</ExtraParams>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="Ollama Data" Target="/root/.ollama" Default="/mnt/user/appdata/ollama" Mode="rw" Description="Ollama models and configuration (shared format with the SYCL image — switching tags reuses downloaded models)" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/ollama</Config>
+  <Config Name="OLLAMA_HOST" Target="OLLAMA_HOST" Default="0.0.0.0:11434" Mode="" Description="Listen address and port" Type="Variable" Display="always" Required="true" Mask="false">0.0.0.0:11434</Config>
+  <Config Name="OLLAMA_DEBUG" Target="OLLAMA_DEBUG" Default="1" Mode="" Description="Enable verbose debug logging" Type="Variable" Display="always" Required="false" Mask="false">1</Config>
+  <Config Name="OLLAMA_KEEP_ALIVE" Target="OLLAMA_KEEP_ALIVE" Default="30s" Mode="" Description="How long to keep models loaded after last request" Type="Variable" Display="always" Required="false" Mask="false">30s</Config>
+  <Config Name="OLLAMA_IGPU_ENABLE" Target="OLLAMA_IGPU_ENABLE" Default="1" Mode="" Description="Ollama drops integrated GPUs by default; 1 opts back in (required for iGPU inference)" Type="Variable" Display="advanced" Required="false" Mask="false">1</Config>
+  <Config Name="OLLAMA_FLASH_ATTENTION" Target="OLLAMA_FLASH_ATTENTION" Default="" Mode="" Description="Set to 0 if you get garbled output on your iGPU" Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="GGML_VK_VISIBLE_DEVICES" Target="GGML_VK_VISIBLE_DEVICES" Default="" Mode="" Description="Restrict to specific Vulkan device IDs (e.g. 0); empty = all devices" Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="OLLAMA_NUM_PARALLEL" Target="OLLAMA_NUM_PARALLEL" Default="" Mode="" Description="Max parallel requests (set to 1 for limited GPU memory; empty = Ollama default)" Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="TZ" Target="TZ" Default="UTC" Mode="" Description="Container timezone" Type="Variable" Display="advanced" Required="false" Mask="false">UTC</Config>
+</Container>


### PR DESCRIPTION
Adds the headline enhancement from the July 2026 audit: a `:vulkan` image tag that runs **stock upstream Ollama** on Intel iGPUs via the Vulkan backend (Mesa ANV driver). This directly fixes the "bundled Ollama is stuck at IPEX-LLM's v0.9.x" gap — upstream is at v0.31.x — and the image is a fraction of the size of the oneAPI/SYCL build.

## What's included

- **`Dockerfile.vulkan`** — `FROM ollama/ollama` (the upstream image already bundles the Vulkan backend) plus `mesa-vulkan-drivers`/`libvulkan1`/`vulkan-tools` for the Intel ICD. Sets `OLLAMA_IGPU_ENABLE=1` because Ollama drops integrated GPUs by default.
- **`start-vulkan.sh`** — logs detected Vulkan devices at startup (`vulkaninfo`), unsets empty optional env vars (same Unraid empty-string fix as the SYCL image), `exec`s Ollama as PID 1.
- **`.github/workflows/build-vulkan.yml`** — builds on push (path-filtered), weekly cron, and manual dispatch. Includes a **smoke test** (container starts, `/api/version` responds) before pushing `:vulkan` and `vulkan-<run>` tags, so a broken upstream release can't ship automatically.
- **`unraid-template-vulkan.xml`** — separate template (`ollama-intel-vulkan`); passes the whole `/dev/dri` instead of hardcoding `card0`; exposes `GGML_VK_VISIBLE_DEVICES`, `OLLAMA_FLASH_ATTENTION`, `OLLAMA_IGPU_ENABLE` as advanced fields.
- README section with a SYCL-vs-Vulkan comparison table and caveats; CHANGELOG entry **v1.3** (renumbered after v1.2 was released for the audit fixes).

## Why experimental

Upstream Vulkan on Intel iGPUs is still maturing: garbled output has been reported on some parts (notably [Arrow Lake with 3B+ models](https://github.com/ollama/ollama/issues/13964), also [Meteor Lake reports](https://github.com/ollama/ollama/issues/13086)). The template, README, and image all document `OLLAMA_FLASH_ATTENTION=0` as the first workaround and `:latest` (SYCL) as the fallback. The variant defaults to `ollama/ollama:latest` at build time so the weekly rebuild tracks upstream — pin via the `OLLAMA_VERSION` build arg if needed.

Both variants can share the same appdata volume (same model store format), but the docs warn against running both containers simultaneously.

## Verification

- CI smoke test runs in the workflow itself before any push to GHCR.
- Real-GPU validation still needs the Meteor Lake box: after merge, the workflow triggers automatically (path filter matches); once `:vulkan` is on GHCR, run it with `--device /dev/dri` and check the startup log lists the Intel device via `vulkaninfo`, then generate with a small model and watch `intel_gpu_top`. Test a 7-8B model for the garbled-output issue before announcing it.
- When merging, tag `v1.3` afterwards to publish the release notes.

> Note: the workflow file was committed via the GitHub web UI (automation token lacks the `workflow` scope); everything else was pushed via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)