### PR TITLE
Cut per-update download from ~3.3 GB to hundreds of MB (layer split + durable build cache)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,58 +2,57 @@ name: Build and Push to GHCR
 
 on:
   push:
-      branches: [main]
-        workflow_dispatch:
-          schedule:
-              - cron: '0 6 * * 0'
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 0'
 
-              env:
-                REGISTRY: ghcr.io
-                  IMAGE_NAME: ${{ github.repository }}
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
-                  jobs:
-                    build-and-push:
-                        runs-on: ubuntu-latest
-                            permissions:
-                                  contents: read
-                                        packages: write
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
-                                            steps:
-                                                  - name: Checkout repository
-                                                          uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-                                                                - name: Log in to GHCR
-                                                                        uses: docker/login-action@v3
-                                                                                with:
-                                                                                          registry: ${{ env.REGISTRY }}
-                                                                                                    username: ${{ github.actor }}
-                                                                                                              password: ${{ secrets.GITHUB_TOKEN }}
-                                                                                                              
-                                                                                                                    - name: Extract metadata
-                                                                                                                            id: meta
-                                                                                                                                    uses: docker/metadata-action@v5
-                                                                                                                                            with:
-                                                                                                                                                      images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                                                                                                                                                                tags: |
-                                                                                                                                                                            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-                                                                                                                                                                                        type=sha,prefix=
-                                                                                                                                                                                                    type=raw,value=${{ github.run_number }}
-                                                                                                                                                                                                    
-                                                                                                                                                                                                          - name: Set up Docker Buildx
-                                                                                                                                                                                                                  uses: docker/setup-buildx-action@v3
-                                                                                                                                                                                                                  
-                                                                                                                                                                                                                        - name: Build and push
-                                                                                                                                                                                                                                uses: docker/build-push-action@v5
-                                                                                                                                                                                                                                        with:
-                                                                                                                                                                                                                                                  context: .
-                                                                                                                                                                                                                                                            push: true
-                                                                                                                                                                                                                                                                      tags: ${{ steps.meta.outputs.tags }}
-                                                                                                                                                                                                                                                                                labels: ${{ steps.meta.outputs.labels }}
-                                                                                                                                                                                                                                                                                          build-args: |
-                                                                                                                                                                                                                                                                                                      CACHE_BUST=${{ github.run_id }}
-                                                                                                                                                                                                                                                                                                                # Registry cache is durable; the default GHA cache (10 GB, 7-day
-                                                                                                                                                                                                                                                                                                                          # eviction) missed on weekly builds, forcing full rebuilds and
-                                                                                                                                                                                                                                                                                                                                    # full re-downloads for users
-                                                                                                                                                                                                                                                                                                                                              cache-from: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache
-                                                                                                                                                                                                                                                                                                                                                        cache-to: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache,mode=max
-                                                                                                                                                                                                                                                                                                                                                        
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=sha,prefix=
+            type=raw,value=${{ github.run_number }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHE_BUST=${{ github.run_id }}
+          # Registry cache is durable; the default GHA cache (10 GB, 7-day
+          # eviction) missed on weekly builds, forcing full rebuilds and
+          # full re-downloads for users
+          cache-from: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache
+          cache-to: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,52 +2,58 @@ name: Build and Push to GHCR
 
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 0'
+      branches: [main]
+        workflow_dispatch:
+          schedule:
+              - cron: '0 6 * * 0'
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+              env:
+                REGISTRY: ghcr.io
+                  IMAGE_NAME: ${{ github.repository }}
 
-jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+                  jobs:
+                    build-and-push:
+                        runs-on: ubuntu-latest
+                            permissions:
+                                  contents: read
+                                        packages: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+                                            steps:
+                                                  - name: Checkout repository
+                                                          uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=sha,prefix=
-            type=raw,value=${{ github.run_number }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+                                                                - name: Log in to GHCR
+                                                                        uses: docker/login-action@v3
+                                                                                with:
+                                                                                          registry: ${{ env.REGISTRY }}
+                                                                                                    username: ${{ github.actor }}
+                                                                                                              password: ${{ secrets.GITHUB_TOKEN }}
+                                                                                                              
+                                                                                                                    - name: Extract metadata
+                                                                                                                            id: meta
+                                                                                                                                    uses: docker/metadata-action@v5
+                                                                                                                                            with:
+                                                                                                                                                      images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                                                                                                                                                                tags: |
+                                                                                                                                                                            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+                                                                                                                                                                                        type=sha,prefix=
+                                                                                                                                                                                                    type=raw,value=${{ github.run_number }}
+                                                                                                                                                                                                    
+                                                                                                                                                                                                          - name: Set up Docker Buildx
+                                                                                                                                                                                                                  uses: docker/setup-buildx-action@v3
+                                                                                                                                                                                                                  
+                                                                                                                                                                                                                        - name: Build and push
+                                                                                                                                                                                                                                uses: docker/build-push-action@v5
+                                                                                                                                                                                                                                        with:
+                                                                                                                                                                                                                                                  context: .
+                                                                                                                                                                                                                                                            push: true
+                                                                                                                                                                                                                                                                      tags: ${{ steps.meta.outputs.tags }}
+                                                                                                                                                                                                                                                                                labels: ${{ steps.meta.outputs.labels }}
+                                                                                                                                                                                                                                                                                          build-args: |
+                                                                                                                                                                                                                                                                                                      CACHE_BUST=${{ github.run_id }}
+                                                                                                                                                                                                                                                                                                                # Registry cache is durable; the default GHA cache (10 GB, 7-day
+                                                                                                                                                                                                                                                                                                                          # eviction) missed on weekly builds, forcing full rebuilds and
+                                                                                                                                                                                                                                                                                                                                    # full re-downloads for users
+                                                                                                                                                                                                                                                                                                                                              cache-from: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache
+                                                                                                                                                                                                                                                                                                                                                        cache-to: type=registry,ref=ghcr.io/ava-agentone/ollama-intel:buildcache,mode=max
+                                                                                                                                                                                                                                                                                                                                                        

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,28 @@
 # runtime 24.52 / IGC 2.5.6 — do not bump the base image or the GPU driver
 # .debs independently. Newer compute-runtime releases (25.x+) are built for
 # Ubuntu 24.04 only and will not install on this jammy base.
+#
+# The RUN steps are deliberately split into layers ordered by change
+# frequency (base tooling → Python → GPU drivers → pinned ipex-llm bulk →
+# weekly upgrade). Only the final layer churns on the weekly rebuild, so
+# users pull hundreds of MB per update instead of the whole multi-GB stack.
+# Do not merge these RUNs back into one.
 FROM intel/oneapi-basekit:2025.0.2-0-devel-ubuntu22.04
 
 ARG http_proxy
 ARG https_proxy
-ARG PIP_NO_CACHE_DIR=false
+
+# Warm-layer pin. Bumping this invalidates the multi-GB torch/ipex-llm layer
+# (users re-download it once), so bump deliberately. The weekly build still
+# picks up newer nightlies in the final upgrade layer.
+ARG IPEX_LLM_VERSION=2.3.0b20251110
 
 # Core environment variables
+# PIP_NO_CACHE_DIR=1: without it, pip's wheel cache (~GBs) gets baked into
+# the image layers.
 ENV TZ=UTC \
     PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
     SYCL_CACHE_PERSISTENT=1 \
     SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 \
     ZES_ENABLE_SYSMAN=1 \
@@ -26,9 +39,8 @@ ENV TZ=UTC \
 # value breaks SYCL device detection. start.sh unsets them when empty, so they
 # are safe to pass via docker run -e or the Unraid template.
 
+# Layer 1: apt repositories + base tooling (rarely changes)
 RUN set -eux && \
-    #
-    # Configure Intel OneAPI and GPU repositories
     wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/intel-oneapi-archive-keyring.gpg > /dev/null && \
     echo "deb [signed-by=/usr/share/keyrings/intel-oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list && \
     chmod 644 /usr/share/keyrings/intel-oneapi-archive-keyring.gpg && \
@@ -36,29 +48,28 @@ RUN set -eux && \
     wget -O- https://repositories.intel.com/graphics/intel-graphics.key | gpg --dearmor | tee /usr/share/keyrings/intel-graphics.gpg > /dev/null && \
     echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/graphics/ubuntu jammy arc" | tee /etc/apt/sources.list.d/intel.gpu.jammy.list && \
     chmod 644 /usr/share/keyrings/intel-graphics.gpg && \
-    #
-    # Install basic dependencies
     apt-get update && \
     apt-get install -y --no-install-recommends \
       curl wget git sudo libunwind8-dev vim less gnupg gpg-agent software-properties-common && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    #
-    # Install Python 3.11
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Layer 2: Python 3.11 + pip (rarely changes)
+RUN set -eux && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get update && \
     apt-get install -y --no-install-recommends python3.11 python3-pip python3.11-dev python3.11-distutils python3-wheel && \
     rm /usr/bin/python3 && ln -s /usr/bin/python3.11 /usr/bin/python3 && \
     ln -s /usr/bin/python3 /usr/bin/python && \
-    #
-    # Install pip and ipex-llm with Ollama support (Intel XPU wheels, no CUDA)
     wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py && \
     python3 get-pip.py && rm get-pip.py && \
-    pip install --upgrade requests argparse urllib3 && \
-    pip install --pre --upgrade ipex-llm[cpp] --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ && \
-    #
-    # Remove conflicting packages
+    pip install --no-cache-dir --upgrade requests argparse urllib3 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Layer 3: pinned Intel GPU userspace drivers (24.52 stack — matches Intel's
+# ipex-llm pin) + Level Zero loader (rarely changes)
+RUN set -eux && \
     apt-get remove -y libze-dev libze-intel-gpu1 || true && \
-    #
-    # Install Intel GPU Compute Runtime (24.52 — matches Intel's ipex-llm pin)
     mkdir -p /tmp/gpu && cd /tmp/gpu && \
     wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb && \
     wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb && \
@@ -70,19 +81,26 @@ RUN set -eux && \
     wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-core_1.0.17537.20_amd64.deb && \
     wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-opencl_1.0.17537.20_amd64.deb && \
     dpkg -i *.deb && rm -rf /tmp/gpu && \
-    #
-    # Install Level Zero loader (newest loader still shipping u22.04 debs;
-    # the loader is backward compatible with the 24.52 driver above)
     mkdir /tmp/level-zero && cd /tmp/level-zero && \
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.31.0/libze1_1.31.0+u22.04_amd64.deb && \
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.31.0/libze-dev_1.31.0+u22.04_amd64.deb && \
-    dpkg -i *.deb && rm -rf /tmp/level-zero && \
-    #
-    # Initialize Ollama binary
-    mkdir -p /llm/ollama && cd /llm/ollama && init-ollama && \
-    #
-    # Cleanup
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    dpkg -i *.deb && rm -rf /tmp/level-zero
+
+# Layer 4: warm ipex-llm install — the multi-GB torch XPU / ipex-llm bulk,
+# pinned so the layer only changes when IPEX_LLM_VERSION is bumped
+RUN pip install --no-cache-dir "ipex-llm[cpp]==${IPEX_LLM_VERSION}" \
+      --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+
+# Layer 5: weekly churn — upgrade to the latest ipex-llm nightly and refresh
+# the Ollama binary. CACHE_BUST (set to the CI run id) forces just this layer
+# to rebuild; everything above stays cached, so the weekly update delta for
+# users is only what actually changed here.
+ARG CACHE_BUST=manual
+RUN set -eux && \
+    echo "cache-bust: ${CACHE_BUST}" && \
+    pip install --no-cache-dir --pre --upgrade "ipex-llm[cpp]" \
+      --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/ && \
+    mkdir -p /llm/ollama && cd /llm/ollama && init-ollama
 
 COPY start.sh /llm/ollama/start.sh
 RUN chmod +x /llm/ollama/start.sh


### PR DESCRIPTION
Follow-up to Esam's report that updating to v1.2 required a ~3 GB download.

## Diagnosis

The GHCR manifest for `:latest` shows 7.53 GB compressed across 13 layers, dominated by two:

- **4.18 GB** — the oneAPI toolkit layer from the pinned base image (cached on hosts, not re-downloaded)
- **3.27 GB** — our single monolithic `RUN`: PyTorch XPU wheels + ipex-llm + GPU driver debs + Ollama **and pip's wheel cache baked in** (`PIP_NO_CACHE_DIR=false`)

Because everything lived in one layer, *any* change — including the weekly `pip --upgrade` — forced users to re-download all 3.27 GB. On top of that, the workflow used GitHub Actions cache (`type=gha`), which has a 10 GB cap and 7-day eviction: the weekly cron regularly missed it, rebuilt from scratch, and produced brand-new layer digests even when nothing meaningful changed.

## Changes

**Dockerfile** — split into 5 layers ordered by change frequency:
1. apt repos + base tooling (rarely changes)
2. Python 3.11 + pip (rarely changes)
3. pinned GPU drivers: compute runtime 24.52 + IGC + Level Zero 1.31.0 (rarely changes)
4. **warm ipex-llm install pinned via `IPEX_LLM_VERSION` build arg** (currently `2.3.0b20251110`, the newest on PyPI) — this is the multi-GB torch/XPU bulk; it only changes when the pin is deliberately bumped
5. weekly churn: `pip --pre --upgrade ipex-llm[cpp]` + `init-ollama`, cache-busted per CI run via the `CACHE_BUST` build arg

Also sets `PIP_NO_CACHE_DIR=1` + `--no-cache-dir`, so pip's wheel cache is no longer baked into the image — the image should shrink outright, likely by 1 GB+.

**build.yml** — switched build cache from `type=gha` to a durable registry cache (`ghcr.io/ava-agentone/ollama-intel:buildcache`, will appear as a new tag in Packages), and passes `CACHE_BUST=${{ github.run_id }}` so only layer 5 rebuilds weekly.

## Expected result

Weekly updates: users pull only layer 5 — roughly the size of a new ipex-llm nightly (~300–600 MB), and effectively ~0 while Intel's pip nightlies remain paused (the newest is from Nov 2025, so the upgrade step currently no-ops).

## Caveats

- **The first update after this merges is one more full ~3 GB+ pull** (all layer digests change once). Savings start from the second update.
- Bumping `IPEX_LLM_VERSION` intentionally invalidates layer 4 → one full re-pull for users. Bump deliberately, note it in the changelog.
- If the `buildcache` tag is ever deleted from GHCR, the next build re-creates it (one-time full rebuild).

## Verification

After merge: the push triggers a build (first run = full rebuild, expect ~30+ min). Then trigger **workflow_dispatch** once more and confirm in the run log that layers 1–4 are `CACHED` and only the final layer rebuilds; the pushed digest delta on GHCR should be small. No container behavior changes — same packages, same entrypoint.

No CHANGELOG/README edits in this PR to avoid conflicting with #7; add a changelog line at the next release.

> Note: build.yml was edited via the web UI (automation token lacks `workflow` scope). The first attempt got mangled by the editor's YAML auto-indent (commit `ec0c259`); commit `dcb8da3` fixed it — the final file is verified byte-identical to the intended content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)